### PR TITLE
extended the script to input event for browser prefill action

### DIFF
--- a/src/jquery-ui.inlinecaptions.js
+++ b/src/jquery-ui.inlinecaptions.js
@@ -46,7 +46,7 @@ $.widget( "ui.inlinecaptions", {
             }
         });
 
-        element.bind('keyup.inlinecaptions change.inlinecaptions', function() {
+        element.bind('keyup.inlinecaptions change.inlinecaptions input.inlinecaptions', function() {
             if ($.trim(element.val()) == '') {
                 if (label.is(':hidden')) {
                     label.fadeIn('fast');


### PR DESCRIPTION
We had some issues with the browser prefill event mainly in firefox. We can prevent it with the "on('input')" function. Was tested on type="text" and type="password". 
